### PR TITLE
Change version to 0.8.2-tq-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+This branch is version `0.8.2-tq-1`, a patch on top of RDF Delta 0.8.2
+that uses Jena 3.15.0. To deploy to TQ's repository:
+
+```
+mvn clean deploy -DaltDeploymentRepository=tq-all::default::https://nexus.topquadrant.com/repository/tq-all
+```
+
+---
+
 # RDF Delta
 
 RDF Delta provides a system for recording and publishing changes to RDF

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.seaborne.rdf-delta</groupId>
   <artifactId>rdf-delta</artifactId>
   <packaging>pom</packaging>
-  <version>0.8.3</version>
+  <version>0.8.2-tq-1</version>
 
   <name>RDF Delta</name>
   <url>https://afs.github.io/rdf-delta/</url>
@@ -69,7 +69,7 @@
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <ver.delta>0.8.3</ver.delta>
+    <ver.delta>0.8.2-tq-1</ver.delta>
     <ver.jena>3.15.0</ver.jena>
 
     <!-- Jena 3.14.0 <ver.jetty>9.4.12.v20180830</ver.jetty> -->

--- a/rdf-delta-base/pom.xml
+++ b/rdf-delta-base/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-client/pom.xml
+++ b/rdf-delta-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-cmds/pom.xml
+++ b/rdf-delta-cmds/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-dist/pom.xml
+++ b/rdf-delta-dist/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-examples/pom.xml
+++ b/rdf-delta-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-fuseki-server/pom.xml
+++ b/rdf-delta-fuseki-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-fuseki/pom.xml
+++ b/rdf-delta-fuseki/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-integration-tests/pom.xml
+++ b/rdf-delta-integration-tests/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-server-extra/pom.xml
+++ b/rdf-delta-server-extra/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-server-http/pom.xml
+++ b/rdf-delta-server-http/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-server-local/pom.xml
+++ b/rdf-delta-server-local/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-delta-server/pom.xml
+++ b/rdf-delta-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent> 
 
   <dependencies>

--- a/rdf-patch/pom.xml
+++ b/rdf-patch/pom.xml
@@ -21,14 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rdf-patch</artifactId>
   <packaging>jar</packaging>
-  <version>${ver.delta}</version>
 
   <name>RDF Patch</name>
 
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.2-tq-1</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
We previously made a patch on top of 0.8.2 and called it 0.8.3. This causes problems now as we are putting all TBS dependencies into a Maven repository. When/if an official 0.8.3 is released, there will be a version clash.

For a patch, it is better to leave the version at 0.8.2 with a qualifier that makes it unique, so this PR renames the version to `0.8.2-tq-1` on a new branch.

The intent of the PR is only to show what has changed and to facilitate code review; I will not actually merge this into the dp-0.8.3 branch.