### PR TITLE
TBS-4248: RDF-Delta 1.0.2-tq-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.seaborne.rdf-delta</groupId>
   <artifactId>rdf-delta</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.2</version>
+  <version>1.0.2-tq-1</version>
 
   <name>RDF Delta</name>
   <url>https://afs.github.io/rdf-delta/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -675,15 +675,9 @@
   </profiles>
 
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh.snapshots</id>
-      <name>Sonatype Snapshots Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
     <repository>
-      <id>ossrh.releases</id>
-      <name>Sonatype Gateway to Maven Central</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>tq-all</id>
+      <url>https://nexus.topquadrant.com/repository/tq-all</url>
     </repository>
   </distributionManagement>
   

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,11 @@
       </snapshots>
     </repository>
 
+    <repository>
+      <id>tq-all</id>
+      <url>https://nexus.topquadrant.com/repository/tq-all</url>
+    </repository>
+
     <!-- Only needed for Jena snapshots - - >
     <repository>
       <id>apache.snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <ver.jena>4.2.0</ver.jena>
+    <ver.jena>4.2.0-tq-1</ver.jena>
     <ver.jetty>10.0.6</ver.jetty>
     <!-- Ensure we get a version compatible with Jena. -->
     <ver.commons-io>2.11.0</ver.commons-io>

--- a/rdf-delta-base/pom.xml
+++ b/rdf-delta-base/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency> 
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-patch</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/rdf-delta-client/pom.xml
+++ b/rdf-delta-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
   </dependencies>
 

--- a/rdf-delta-cmds/pom.xml
+++ b/rdf-delta-cmds/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -75,32 +75,32 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
      <!-- Only for the patch service -->
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
     <!-- With jena-text -->
     <dependency>
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-dist/pom.xml
+++ b/rdf-delta-dist/pom.xml
@@ -27,26 +27,26 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <dependencies>
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki-server</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
   </dependencies>

--- a/rdf-delta-examples/pom.xml
+++ b/rdf-delta-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,19 +38,19 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->

--- a/rdf-delta-fuseki-server/pom.xml
+++ b/rdf-delta-fuseki-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency> 
  
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency> 
 
     <dependency>

--- a/rdf-delta-fuseki/pom.xml
+++ b/rdf-delta-fuseki/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId> 
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-integration-tests/pom.xml
+++ b/rdf-delta-integration-tests/pom.xml
@@ -110,8 +110,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+		  <!--
+		    Some of the test data files are not closed properly during test
+			teardown and, on Windows, cannot be deleted by subsequent test
+			setups, causing those subsequent tests to fail,
+			typically during setup.
+			A workaround is to configure the Maven Surefire plugin to execute
+			every "test suite class" in a new JVM instance; as done below.
+			As a result, all the test data files are closed when the JVM is
+			terminated at the completion of each test suite and subsequent
+			test suites can perform their setups without any problems.
+			https://github.com/afs/rdf-delta/issues/120
+		  -->
+		  <reuseForks>false</reuseForks>
           <includes>
-            <include>**/TC_*.java</include>
+            <include>Test*.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/rdf-delta-integration-tests/pom.xml
+++ b/rdf-delta-integration-tests/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaClient.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaClient.java
@@ -45,6 +45,7 @@ public abstract class AbstractTestDeltaClient {
         LogX.setJavaLogging("src/test/resources/logging.properties");
         Location loc = Location.create(DIR_ZONE);
         FileOps.ensureDir(DIR_ZONE);
+        FileOps.clearAll(DIR_ZONE);
         zone = Zone.connect(DIR_ZONE);
     }
 

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/BaseTestDeltaFuseki.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/BaseTestDeltaFuseki.java
@@ -112,7 +112,7 @@ public class BaseTestDeltaFuseki {
     private static FusekiServer fuseki(Start state, int port, int deltaPort, String config, String zone) {
         // Replace %D_PORT%
         String text = IOX.readWholeFileAsUTF8(config);
-        String baseIRI = IRILib.filenameToIRI(text);
+        String baseIRI = IRILib.filenameToIRI(config);
         text = text.replace(D_PORT_MARKER, Integer.toString(deltaPort));
         Model confModel = ModelFactory.createDefaultModel();
         RDFParser.create().base(baseIRI).source(new StringReader(text)).lang(Lang.TTL).parse(confModel);

--- a/rdf-delta-server-extra/pom.xml
+++ b/rdf-delta-server-extra/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-server-http/pom.xml
+++ b/rdf-delta-server-http/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <!-- The HTTP Server needs Jetty. The easy way to do that is ... -->

--- a/rdf-delta-server-local/pom.xml
+++ b/rdf-delta-server-local/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-server/pom.xml
+++ b/rdf-delta-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <!-- Put the cmds in as well for convenience.
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.2-tq-1</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->

--- a/rdf-patch/pom.xml
+++ b/rdf-patch/pom.xml
@@ -21,14 +21,14 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rdf-patch</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.2-tq-1</version>
 
   <name>RDF Patch</name>
 
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-tq-1</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
Changes:
* Bump the Maven version to 1.0.2-tq-1
* Pull in Jena 4.2.0-tq-1
* Fix the integration tests for Windows

This is more of a "review request", as the changes will not be merged into 'main'.

Pre-requisite:
* Build and install (`mvn clean install`) this Jena patch:\
https://github.com/TopQuadrant/jena/pull/1