### PR TITLE
TBS-5987 upgrade to Jena 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,9 @@
           <version>3.3.0</version>
           <configuration> 
             <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
               <manifestEntries>
                 <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
               </manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.seaborne.rdf-delta</groupId>
   <artifactId>rdf-delta</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.2-tq-2</version>
+  <version>1.1.2-tq-3</version>
 
   <name>RDF Delta</name>
   <url>https://afs.github.io/rdf-delta/</url>
@@ -70,8 +70,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
 
-    <ver.jena>4.8.0</ver.jena>
-    <ver.jetty>10.0.13</ver.jetty>
+    <ver.jena>4.9.0</ver.jena>
+    <ver.jetty>10.0.15</ver.jetty>
     <!-- Ensure we get a version compatible with Jena. -->
     <ver.commons-io>2.11.0</ver.commons-io>
     <ver.junit>4.13.2</ver.junit>

--- a/rdf-delta-base/pom.xml
+++ b/rdf-delta-base/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>

--- a/rdf-delta-base/src/main/java/org/seaborne/delta/lib/SystemInfo.java
+++ b/rdf-delta-base/src/main/java/org/seaborne/delta/lib/SystemInfo.java
@@ -17,27 +17,19 @@
 
 package org.seaborne.delta.lib;
 
-import org.apache.jena.util.Metadata;
+import org.apache.jena.atlas.lib.Version;
 
 public class SystemInfo {
     /**
      * A relative resources path to the location of
      * <code>delta-properties.xml</code> file.
      */
-    static private String   metadataLocation             = "org/seaborne/delta/delta-properties.xml";
-
-    static private Metadata metadata                     = initMetadata();
-
-    private static Metadata initMetadata() {
-        Metadata m = new Metadata();
-        m.addMetadata(metadataLocation);
-        return m;
-    }
 
     /** Property path name base */
     private static final String PATH = "org.seaborne.delta";
 
     public static String systemName()   { return "RDF Delta"; }
-    public static String version()      { return metadata.get(PATH + ".version", "development"); }
-    public static String buildDate()    { return metadata.get(PATH + ".build.datetime", "unknown"); }
+    public static String version()      { return Version.versionForClass(SystemInfo.class).orElse("development"); }
+    @Deprecated
+    public static String buildDate()    { return ""; }
 }

--- a/rdf-delta-client/pom.xml
+++ b/rdf-delta-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
   </dependencies>
 

--- a/rdf-delta-cmds/pom.xml
+++ b/rdf-delta-cmds/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -58,32 +58,32 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
      <!-- Only for the patch service -->
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
     <!-- With jena-text -->
     <dependency>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-cmds/src/main/java/org/seaborne/delta/cmds/dcmd.java
+++ b/rdf-delta-cmds/src/main/java/org/seaborne/delta/cmds/dcmd.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.apache.jena.cmd.CmdException;
 import org.apache.jena.Jena;
 import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.atlas.lib.Version;
 import org.apache.jena.fuseki.main.cmds.FusekiMainCmd;
 import org.seaborne.delta.Delta;
 import org.seaborne.delta.lib.SystemInfo;
@@ -49,10 +50,8 @@ public class dcmd {
 //        system.addMetadata("org/apache/jena/jena-properties.xml");
         // Need rewriting! Put back "name".
         // No reflection foo.
-        org.apache.jena.atlas.lib.Version version = new org.apache.jena.atlas.lib.Version();
-        version.addClass(RDF_Delta.class);
-        version.addClass(Jena.class) ;
-        version.print(IndentedWriter.stdout);
+        System.out.println(Version.versionForClass(RDF_Delta.class));
+        System.out.println(Version.versionForClass(Jena.class));
     }
 
     public static void main(String...args) {

--- a/rdf-delta-cmds/src/main/java/org/seaborne/delta/cmds/dcmd.java
+++ b/rdf-delta-cmds/src/main/java/org/seaborne/delta/cmds/dcmd.java
@@ -50,8 +50,8 @@ public class dcmd {
 //        system.addMetadata("org/apache/jena/jena-properties.xml");
         // Need rewriting! Put back "name".
         // No reflection foo.
-        System.out.println(Version.versionForClass(RDF_Delta.class));
-        System.out.println(Version.versionForClass(Jena.class));
+        System.out.format("%s:  VERSION: %s\n", RDF_Delta.class.getSimpleName(), Version.versionForClass(RDF_Delta.class).orElse("<development>"));
+        System.out.format("%s:       VERSION: %s\n", Jena.class.getSimpleName(), Version.versionForClass(Jena.class).orElse("<development>"));
     }
 
     public static void main(String...args) {

--- a/rdf-delta-dist/pom.xml
+++ b/rdf-delta-dist/pom.xml
@@ -27,26 +27,26 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <dependencies>
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki-server</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
   </dependencies>

--- a/rdf-delta-examples/pom.xml
+++ b/rdf-delta-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -38,19 +38,19 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->

--- a/rdf-delta-fuseki-server/pom.xml
+++ b/rdf-delta-fuseki-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency> 
  
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency> 
 
     <dependency>

--- a/rdf-delta-fuseki/pom.xml
+++ b/rdf-delta-fuseki/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId> 
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-integration-tests/pom.xml
+++ b/rdf-delta-integration-tests/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaConnection.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaConnection.java
@@ -19,13 +19,13 @@ package org.seaborne.delta;
 
 import static org.junit.Assert.*;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger ;
 import java.util.stream.LongStream;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.FileOps;
-import org.apache.jena.ext.com.google.common.base.Objects;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
@@ -553,6 +553,6 @@ public abstract class AbstractTestDeltaConnection {
         RDFChangesCollector c2 = new RDFChangesCollector();
         RDFChangesCollector.RDFPatchStored p2 = (RDFChangesCollector.RDFPatchStored)c2.getRDFPatch();
 
-        return Objects.equal(p1, p2);
+        return Objects.equals(p1, p2);
     }
 }

--- a/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaLink.java
+++ b/rdf-delta-integration-tests/src/test/java/org/seaborne/delta/AbstractTestDeltaLink.java
@@ -632,8 +632,7 @@ public abstract class AbstractTestDeltaLink {
             @Override public void notifyDeleteList (Graph g, List<Triple> triples) {}
             @Override public void notifyDeleteTriple(Graph g, Triple t) {}
             @Override public void notifyEvent(Graph source, Object value) {}
-            protected void deleteEvent(Triple t) {}
-            protected void addEvent(Triple t) { counter.incrementAndGet(); }
+            private void addEvent(Triple t) { counter.incrementAndGet(); }
         };
         g.getEventManager().register(gl);
 

--- a/rdf-delta-server-extra/pom.xml
+++ b/rdf-delta-server-extra/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-server-http/pom.xml
+++ b/rdf-delta-server-http/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <!-- The HTTP Server needs Jetty. The easy way to do that is ... -->

--- a/rdf-delta-server-local/pom.xml
+++ b/rdf-delta-server-local/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <dependency>
@@ -62,6 +62,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.2-jre</version>
     </dependency>
 
   </dependencies>

--- a/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/filestore/FS.java
+++ b/rdf-delta-server-local/src/main/java/org/seaborne/delta/server/local/patchstores/filestore/FS.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.jena.atlas.logging.FmtLog;
-import org.apache.jena.ext.com.google.common.collect.BiMap;
+import com.google.common.collect.BiMap;
 import org.seaborne.delta.Id;
 import org.seaborne.delta.Version;
 import org.apache.jena.atlas.io.IOX;

--- a/rdf-delta-server/pom.xml
+++ b/rdf-delta-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>1.1.2-tq-2</version>
+    <version>1.1.2-tq-3</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <!-- Put the cmds in as well for convenience.
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>1.1.2-tq-2</version>
+      <version>1.1.2-tq-3</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->


### PR DESCRIPTION
- update version number for TQ fork release to 1.1.2-tq-3
- update Jetty version to match Jena
- Jena's Metadata class was removed, so use Version instead
- use Java Objects instead of guava
- implement GraphListener methods from removed GraphListenerBase
- use BiMap directly from guava instead of removed Jena version