### PR TITLE
TBS-7194 version to 2.0.0-tq-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>org.seaborne.rdf-delta</groupId>
   <artifactId>rdf-delta</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0-tq-1</version>
 
   <name>RDF Delta</name>
   <url>https://afs.github.io/rdf-delta/</url>

--- a/rdf-delta-base/pom.xml
+++ b/rdf-delta-base/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>

--- a/rdf-delta-client/pom.xml
+++ b/rdf-delta-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
   </dependencies>
 

--- a/rdf-delta-cmds/pom.xml
+++ b/rdf-delta-cmds/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -58,32 +58,32 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
      <!-- Only for the patch service -->
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
     <!-- With jena-text -->
     <dependency>
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-extra</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-dist/pom.xml
+++ b/rdf-delta-dist/pom.xml
@@ -27,26 +27,26 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <dependencies>
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki-server</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
   </dependencies>

--- a/rdf-delta-examples/pom.xml
+++ b/rdf-delta-examples/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,19 +38,19 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->

--- a/rdf-delta-fuseki-server/pom.xml
+++ b/rdf-delta-fuseki-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-fuseki</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency> 
  
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency> 
 
     <dependency>

--- a/rdf-delta-fuseki/pom.xml
+++ b/rdf-delta-fuseki/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId> 
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-integration-tests/pom.xml
+++ b/rdf-delta-integration-tests/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-client</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-server-extra/pom.xml
+++ b/rdf-delta-server-extra/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -39,13 +39,13 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/rdf-delta-server-http/pom.xml
+++ b/rdf-delta-server-http/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-local</artifactId> 
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <!-- The HTTP Server needs Jetty. The easy way to do that is ... -->

--- a/rdf-delta-server-local/pom.xml
+++ b/rdf-delta-server-local/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-base</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <dependency>

--- a/rdf-delta-server/pom.xml
+++ b/rdf-delta-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.seaborne.rdf-delta</groupId>
     <artifactId>rdf-delta</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-tq-1</version>
   </parent> 
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-server-http</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <!-- Put the cmds in as well for convenience.
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.seaborne.rdf-delta</groupId>
       <artifactId>rdf-delta-cmds</artifactId>
-      <version>2.0.0-SNAPSHOT</version>
+      <version>2.0.0-tq-1</version>
     </dependency>
 
     <!-- LOGGING : Require a logging implementation -->


### PR DESCRIPTION
This PR must be approved before the corresponding TBS PR is created. This is so the RDF Delta build artifacts can be deployed to TQ Nexus and the TBS PR pull them in during the pre-flight build etc.